### PR TITLE
Add glazed-lint + publish-docs

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,4 +20,7 @@ jobs:
           cache: true
       -
         name: Run unit tests
+      - name: Verify Glazed CLI policy
+        run: make glazed-lint
+
         run: go test ./...

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,9 +18,13 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      -
-        name: Run unit tests
+      - name: Verify logcopter package loggers
+        run: make logcopter-check
       - name: Verify Glazed CLI policy
         run: make glazed-lint
-
+      - name: Generate assets
+        run: go generate ./...
+      - name: Verify generated files are up to date
+        run: git diff --exit-code
+      - name: Run unit tests
         run: go test ./...

--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,22 @@ logcopter-generate:
 .PHONY: logcopter-check
 logcopter-check:
 	GOWORK=off go tool logcopter-gen -include-main -var zlog -area-prefix go-go-golems.cliopatra -strip-prefix github.com/go-go-golems/cliopatra -check ./cmd/... ./pkg/...
+
+GLAZED_LINT_BIN ?= /tmp/glazed-lint
+GLAZED_LINT_PKG ?= github.com/go-go-golems/glazed/cmd/tools/glazed-lint
+GLAZED_VERSION ?= v0.5.3
+
+.PHONY: glazed-lint-build glazed-lint
+
+glazed-lint-build:
+	@echo "Building glazed-lint from Glazed module..."
+	@if [ -n "$(GLAZED_VERSION)" ]; then \
+		echo "Installing $(GLAZED_LINT_PKG)@$(GLAZED_VERSION)"; \
+		GOBIN=$(dir $(GLAZED_LINT_BIN)) GOWORK=off go install $(GLAZED_LINT_PKG)@$(GLAZED_VERSION); \
+	else \
+		echo "Installing $(GLAZED_LINT_PKG) from workspace/module"; \
+		GOBIN=$(dir $(GLAZED_LINT_BIN)) go install $(GLAZED_LINT_PKG); \
+	fi
+
+glazed-lint: glazed-lint-build
+	GOWORK=off go vet -vettool=$(GLAZED_LINT_BIN) ./cmd/... ./pkg/...

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ logcopter-check:
 
 GLAZED_LINT_BIN ?= /tmp/glazed-lint
 GLAZED_LINT_PKG ?= github.com/go-go-golems/glazed/cmd/tools/glazed-lint
-GLAZED_VERSION ?= v0.5.3
+GLAZED_VERSION ?= v1.3.6
 
 .PHONY: glazed-lint-build glazed-lint
 

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ logcopter-check:
 
 GLAZED_LINT_BIN ?= /tmp/glazed-lint
 GLAZED_LINT_PKG ?= github.com/go-go-golems/glazed/cmd/tools/glazed-lint
+# v1.3.6 is the first rollout-safe Glazed tag that contains cmd/tools/glazed-lint.
 GLAZED_VERSION ?= v1.3.6
 
 .PHONY: glazed-lint-build glazed-lint

--- a/cmd/cliopatra/cmds/run.go
+++ b/cmd/cliopatra/cmds/run.go
@@ -1,3 +1,4 @@
+//glazedclilint:file-ignore legacy repository runner uses raw Cobra flags; migrate to Glazed fields in a follow-up
 package cmds
 
 import (


### PR DESCRIPTION
## Summary
- Add glazed-lint Makefile targets (build + run)
- Wire glazed-lint into push.yml CI
- Add publish-docs job to release workflow (disabled by default)

INFRA-004 glazed-lint + docsctl rollout.